### PR TITLE
Fix private emails and special chars in initials key

### DIFF
--- a/src/authors/co-authors.js
+++ b/src/authors/co-authors.js
@@ -24,7 +24,7 @@ class CoAuthor extends Author {
 }
 
 function createAuthor(stdoutFormat) {
-  const regexList = /^([a-zA-Z0-9_\-\.]+)\s(.+)\s([a-zA-Z0-9_\-\.]+@[a-zA-Z0-9_\-\.]+\.[a-zA-Z]{2,5})/;
+  const regexList = /^([\S]+)\s(.+)\s([a-zA-Z0-9_\-\.\+]+@[a-zA-Z0-9_\-\.]+\.[a-zA-Z]{2,5})/;
   let list = stdoutFormat.match(regexList);
   const [, commandKey, name, email] = list;
   return new CoAuthor(name, email, false, commandKey);

--- a/src/authors/co-authors.spec.js
+++ b/src/authors/co-authors.spec.js
@@ -9,11 +9,28 @@ describe("Co-author creation", function() {
     );
   });
 
-  it("can have other character for key than a-z", function() {
+  it("can have symbol character for key", function() {
     let coAuthorList = createAuthor(`ri3-h richard kotze rkotze@email.com`);
 
     expect(coAuthorList).toEqual(
       new CoAuthor("richard kotze", "rkotze@email.com", false, "ri3-h")
     );
   });
+
+  it("can have special character for key", function() {
+    let coAuthorList = createAuthor(`ričßh richard kotze rkotze@email.com`);
+
+    expect(coAuthorList).toEqual(
+      new CoAuthor("richard kotze", "rkotze@email.com", false, "ričßh")
+    );
+  });
+
+  it("author uses a private GitHub email", function() {
+    let coAuthorList = createAuthor(`tsus Tony Stark 20342323+tony@users.noreply.github.com`);
+
+    expect(coAuthorList).toEqual(
+      new CoAuthor("Tony Stark", "20342323+tony@users.noreply.github.com", false, "tsus")
+    );
+  });
+
 });


### PR DESCRIPTION
- fix reading private mails from git mob -l
- allow initial key to include specials chars
- fix #19