### PR TITLE
Scope `npx` to `git-mob` package

### DIFF
--- a/src/git/commands.js
+++ b/src/git/commands.js
@@ -65,7 +65,7 @@ function has(key) {
 }
 
 function gitMobLatest() {
-  const version = silentRun("npx git mob -v");
+  const version = silentRun("npx --package=git-mob git mob -v");
   if (version.status !== 0) return 1;
   return compare("1.1.0", version.stdout);
 }
@@ -82,30 +82,30 @@ async function getRepoAuthors() {
 function addRepoAuthor({ commandKey, name, email }) {
   if (process.platform === "win32") {
     return silentRun(
-      `npx git add-coauthor ${commandKey} \\"${name}\\" ${email}`
+      `npx --package=git-mob git add-coauthor ${commandKey} \\"${name}\\" ${email}`
     );
   }
-  return silentRun(`npx git add-coauthor ${commandKey} "${name}" ${email}`);
+  return silentRun(`npx --package=git-mob git add-coauthor ${commandKey} "${name}" ${email}`);
 }
 
 function setCurrent(mobList) {
-  return format(handleResponse(`npx git mob ${mobList.join(" ")}`));
+  return format(handleResponse(`npx --package=git-mob git mob ${mobList.join(" ")}`));
 }
 
 function changeAuthor(authorKey) {
-  return format(handleResponse(`npx git mob -o ${authorKey}`));
+  return format(handleResponse(`npx --package=git-mob git mob -o ${authorKey}`));
 }
 
 function solo() {
-  return format(handleResponse(`npx git solo`));
+  return format(handleResponse(`npx --package=git-mob git solo`));
 }
 
 function current() {
-  return format(handleResponse(`npx git mob`));
+  return format(handleResponse(`npx --package=git-mob git mob`));
 }
 
 function listAll() {
-  return format(handleResponse(`npx git mob --list`));
+  return format(handleResponse(`npx --package=git-mob git mob --list`));
 }
 
 function format(stdout) {


### PR DESCRIPTION
This commit scopes `npx` commands to `--package=git-mob`. Otherwise, if you have other packages with `git` binaries, the call to `npx` is ambiguous and it fails.