### PR TITLE
Update Pipelines use Ubuntu latest

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -4,7 +4,7 @@ trigger:
   - master
 
 pool:
-  vmImage: ubuntu-16.04
+  vmImage: ubuntu-latest
 
 steps:
   # for convenience, we tag CI-produced packages with a version number


### PR DESCRIPTION
Looks like the Ubuntu image was no longer supported. Decided to use latest since the OS version should not affect the build pipleline.