### PR TITLE
Update to use multiple versions of node

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,8 +17,16 @@ on:
 jobs:
   # This workflow contains a single job called "build"
   build:
+    name: Node.js ${{ matrix.node-version }}
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version:
+          - 20
+          - 18
+          - 16
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -31,7 +39,7 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@v3
         with:
-          node-version: '16'
+          node-version: ${{ matrix.node-version }}
 
       - name: Install dependencies
         run: npm install

--- a/.github/workflows/dependabot-approve-and-auto-merge.yml
+++ b/.github/workflows/dependabot-approve-and-auto-merge.yml
@@ -1,6 +1,10 @@
 name: Dependabot Pull Request Approve and Merge
 
-on: pull_request_target
+on:
+  workflow_run:
+    workflows: [CI]
+    types:
+      - completed
 
 permissions:
   pull-requests: write

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@v3
         with:
-          node-version: '16'
+          node-version: '20'
 
       - name: Install dependencies
         run: npm install


### PR DESCRIPTION

## What changes?

- Use multiple node versions to test code 20, 18 and 16
- Dependabot to depend on CI workflow passing before trying to merge